### PR TITLE
Make terminal a pre tag to preserve formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,8 @@
             }
         </style>
     </head>
-    <body>"
-        <div class="terminal" id="terminal">
-        </div>
+    <body>
+        <pre class="terminal" id="terminal"></pre>
         <script>
             var code = `#include <linux/delay.h>
 #include <linux/init.h>


### PR DESCRIPTION
This PR makes the element identified by `terminal` a `pre` tag to preserve the original formatting. [The result is online for you to check out](https://hellerve.github.io/html5hacker/). You should see the difference relatively clearly as soon as the variables/functions start to show up!

Cheers